### PR TITLE
Patch reflow-velocity-tools for Maven Site Plugin 3.5 and higher.

### DIFF
--- a/reflow-velocity-tools/src/main/resources/META-INF/maven/site-tools.xml
+++ b/reflow-velocity-tools/src/main/resources/META-INF/maven/site-tools.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Add custom tools to Velocity tools. The tools.xml file is included in the classpath and Velocity finds it. -->
+<tools>
+  <toolbox scope="application">
+    <tool key="config"
+          class="lt.velykis.maven.skins.reflow.SkinConfigTool"/>
+    <tool key="htmlTool"
+          class="lt.velykis.maven.skins.reflow.HtmlTool"/>
+    <tool key="uriTool"
+          class="lt.velykis.maven.skins.reflow.URITool"/>
+  </toolbox>
+</tools>


### PR DESCRIPTION
 - see also https://issues.apache.org/jira/browse/MSITE-782 about classpath:/META-INF/maven/site-tools.xml.